### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,11 +1,11 @@
 # Syntax Coloring Map For ModbusIP
 
 # Datatypes (KEYWORD1)
-ModbusIP	 KEYWORD1
-ModbusIP_ESP8266 KEYWORD1
+ModbusIP	KEYWORD1
+ModbusIP_ESP8266	KEYWORD1
 
 # Methods and Functions (KEYWORD2)
-config          KEYWORD2
-task            KEYWORD2
+config	KEYWORD2
+task	KEYWORD2
 
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords